### PR TITLE
Load DB credentials from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+19_moviestar/config.ini

--- a/19_moviestar/db.php
+++ b/19_moviestar/db.php
@@ -1,12 +1,18 @@
 <?php
 
-  $db_name = "moviestar";
-  $db_host = "localhost";
-  $db_user = "root";
-  $db_pass = "";
+$configPath = __DIR__ . '/config.ini';
+$config = [];
+if (file_exists($configPath)) {
+    $config = parse_ini_file($configPath);
+}
 
-  $conn = new PDO("mysql:dbname=". $db_name .";host=". $db_host, $db_user, $db_pass);
+$db_name = getenv('DB_NAME') ?: ($config['DB_NAME'] ?? 'moviestar');
+$db_host = getenv('DB_HOST') ?: ($config['DB_HOST'] ?? 'localhost');
+$db_user = getenv('DB_USER') ?: ($config['DB_USER'] ?? 'root');
+$db_pass = getenv('DB_PASS') ?: ($config['DB_PASS'] ?? '');
 
-  // Habilitar erros PDO
-  $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  $conn->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+$conn = new PDO("mysql:dbname=" . $db_name . ";host=" . $db_host, $db_user, $db_pass);
+
+// Habilitar erros PDO
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conn->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # EIVOM
+
+## Configuração de Banco de Dados
+
+O arquivo `19_moviestar/db.php` utiliza variáveis de ambiente ou um arquivo `config.ini` para definir as informações de acesso ao banco de dados.
+
+Defina as variáveis de ambiente abaixo antes de executar o projeto:
+
+- `DB_NAME`
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASS`
+
+Como alternativa, crie um arquivo `19_moviestar/config.ini` com o conteúdo:
+
+```
+DB_NAME=nome_do_banco
+DB_HOST=localhost
+DB_USER=usuario
+DB_PASS=senha
+```
+
+O `config.ini` está listado no `.gitignore` e não deve ser versionado para que as credenciais permaneçam seguras.


### PR DESCRIPTION
## Summary
- allow `19_moviestar/db.php` to read DB configuration from environment variables or a `config.ini`
- document how to set these variables
- ignore `config.ini` so sensitive data isn't committed

## Testing
- `php -l 19_moviestar/db.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850be737ab88322a4b134ffb1cddf7c